### PR TITLE
Remove autoindex

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,12 @@
 
 # tasks for apache
 - name: ensure apache packages are installed
-  yum: name="{{ packages }}" state=present lock_timeout=180
-  vars:
-    packages:
+  yum:
+    name:
       - httpd
       - collectd-apache
+    state: present
+    lock_timeout: 180
   tags: ['apache']
 
 - name: ensure the base httpd config is in place
@@ -39,9 +40,9 @@
   tags: ['apache']
 
 - name: ensure mod_autoindex is disabled
-  file:
-    path: "/etc/httpd/conf.d/autoindex.conf"
-    state: absent
+  copy:
+    content: "# This file intentionally left blank"
+    dest: "/etc/httpd/conf.d/autoindex.conf"
   notify: restart httpd
   tags: ['apache']
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,10 +10,11 @@
 
 # tasks for apache
 - name: ensure apache packages are installed
-  yum: name={{ item }} state=present lock_timeout=180
-  with_items:
-    - httpd
-    - collectd-apache
+  yum: name="{{ packages }}" state=present lock_timeout=180
+  vars:
+    packages:
+      - httpd
+      - collectd-apache
   tags: ['apache']
 
 - name: ensure the base httpd config is in place

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # compat for amazon linux
 - set_fact: ansible_distribution_major_version=6
-  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA" 
+  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
   tags: ['apache']
 
 - set_fact: ansible_distribution_major_version=7
@@ -35,6 +35,13 @@
     mode: 0644
   notify: restart httpd
   when: ansible_distribution_major_version == '7'
+  tags: ['apache']
+
+- name: ensure mod_autoindex is disabled
+  file:
+    path: "/etc/httpd/conf.d/autoindex.conf"
+    state: absent
+  notify: restart httpd
   tags: ['apache']
 
 - name: ensure the collectd httpd config is in place


### PR DESCRIPTION
Remove autoindex.conf from apache installs, we don't need or want it?

